### PR TITLE
Adding support for signing using IAM User temporary credentials

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -11,8 +11,8 @@ import (
 
 func ExampleSign() {
 	keys := Keys{
-		os.Getenv("S3_ACCESS_KEY"),
-		os.Getenv("S3_SECRET_KEY"),
+		AccessKey: os.Getenv("S3_ACCESS_KEY"),
+		SecretKey: os.Getenv("S3_SECRET_KEY"),
 	}
 	data := strings.NewReader("hello, world")
 	r, _ := http.NewRequest("PUT", "https://example.s3.amazonaws.com/foo", data)

--- a/sign.go
+++ b/sign.go
@@ -43,6 +43,10 @@ var signParams = map[string]bool{
 type Keys struct {
 	AccessKey string
 	SecretKey string
+	// Used for temporary security credentials. Leave blank to use
+	// standard AWS Account or IAM credentials.
+	// See http://docs.aws.amazon.com/AmazonS3/latest/dev/MakingRequests.html#TypesofSecurityCredentials
+	SecurityToken string
 }
 
 // The default Service used by Sign.
@@ -62,6 +66,9 @@ type Service struct {
 
 // Sign signs an HTTP request with the given S3 keys for use on service s.
 func (s *Service) Sign(r *http.Request, k Keys) {
+	if k.SecurityToken != "" {
+		r.Header.Set("X-Amz-Security-Token", k.SecurityToken)
+	}
 	h := hmac.New(sha1.New, []byte(k.SecretKey))
 	s.writeSigData(h, r)
 	sig := make([]byte, base64.StdEncoding.EncodedLen(h.Size()))

--- a/sign_test.go
+++ b/sign_test.go
@@ -7,8 +7,15 @@ import (
 )
 
 var exKeys = Keys{
-	"AKIAIOSFODNN7EXAMPLE",
-	"wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+	AccessKey: "AKIAIOSFODNN7EXAMPLE",
+	SecretKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+}
+
+// Temporary Credentials
+var tokenExKeys = Keys{
+	AccessKey:     "AKIAIOSFODNN7EXAMPLE",
+	SecretKey:     "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+	SecurityToken: "dummy",
 }
 
 var signTest = []struct {
@@ -153,6 +160,16 @@ func TestSign(t *testing.T) {
 			t.Errorf("in %s:", r.Method)
 			t.Logf("url %s", r.URL.String())
 			t.Logf("exp %q", ts.expSig)
+			t.Logf("got %q", got)
+		}
+
+        // Reset Auth header and test signing with temporary credentials
+		r.Header.Del("Authorization")
+		DefaultService.Sign(r, tokenExKeys)
+		if got := r.Header.Get("X-Amz-Security-Token"); got != tokenExKeys.SecurityToken {
+			t.Errorf("in %s:", r.Method)
+			t.Logf("url %s", r.URL.String())
+			t.Logf("exp %q", tokenExKeys.SecurityToken)
 			t.Logf("got %q", got)
 		}
 	}


### PR DESCRIPTION
Here are more details in the S3 Documentation.

Does this approach sound okay, or would you rather that the consumer of the API manually add a header to include the security token in the header?
