### PR TITLE
Fix signature sorting of common prefix keys.

### DIFF
--- a/sign.go
+++ b/sign.go
@@ -163,14 +163,19 @@ func (s *Service) writeSubResource(w io.Writer, r *http.Request) {
 }
 
 func writeAmzHeaders(w io.Writer, r *http.Request) {
-	var a []string
-	for k, v := range r.Header {
-		k = strings.ToLower(k)
-		if strings.HasPrefix(k, "x-amz-") {
-			a = append(a, k+":"+strings.Join(v, ","))
+	var keys []string
+	for k, _ := range r.Header {
+		if strings.HasPrefix(strings.ToLower(k), "x-amz-") {
+			keys = append(keys, k)
 		}
 	}
-	sort.Strings(a)
+
+	sort.Strings(keys)
+	var a []string
+	for _, k := range keys {
+		v := r.Header[k]
+		a = append(a, strings.ToLower(k)+":"+strings.Join(v, ","))
+	}
 	for _, h := range a {
 		w.Write([]byte(h))
 		w.Write([]byte{'\n'})

--- a/sign_test.go
+++ b/sign_test.go
@@ -167,6 +167,18 @@ var signTest = []struct {
 		"GET\n\n\nTue, 27 Mar 2007 19:36:42 +0000\n/bucket/ubuntu-12.04.2-server-amd64.iso",
 		"AWS AKIAIOSFODNN7EXAMPLE:eLAv1CJmnBwV4DXj2z508eunQQs=",
 	},
+	{
+		DefaultService,
+		"PUT",
+		"http://static.johnsmith.net:8080/db-backup.dat.gz",
+		http.Header{
+			"Date":                    {"Tue, 27 Mar 2007 21:06:08 +0000"},
+			"X-Amz-Copy-Source":       {"other_object"},
+			"X-Amz-Copy-Source-Range": {"bytes=0-960463"},
+		},
+		"PUT\n\n\nTue, 27 Mar 2007 21:06:08 +0000\nx-amz-copy-source:other_object\nx-amz-copy-source-range:bytes=0-960463\n/static.johnsmith.net/db-backup.dat.gz",
+		"AWS AKIAIOSFODNN7EXAMPLE:rH0p5yotiFsFs8BnYl9cS/MBXvk=",
+	},
 }
 
 func TestSign(t *testing.T) {


### PR DESCRIPTION
The AwzHeaders need to be sorted by key, not key+value.

For example the following headers would sort incorrectly before this patch:

```
X-Amz-Copy-Source:other_object
X-Amz-Copy-Source-Range:bytes=0-960463"
```

In this example X-Amz-Copy-Source should sort before X-Amz-Copy-Source-Range, but sorting was happening after joining the header key and value so  X-Amz-Copy-Source-Range was sorting first (b/c '-' is less than ':').

This patch sorts the keys first and then joins the strings for the signature algorithm.
