### PR TITLE
Allow remote signing by introducing Signer interface

### DIFF
--- a/Readme
+++ b/Readme
@@ -1,4 +1,4 @@
 Package s3 signs HTTP requests for use with Amazon’s S3 API.
 
 Documentation:
-http://godoc.org/github.com/kr/s3
+http://godoc.org/github.com/guymguym/s3

--- a/example_test.go
+++ b/example_test.go
@@ -1,7 +1,7 @@
 package s3_test
 
 import (
-	"../s3"
+	"github.com/guymguym/s3"
 	"fmt"
 	"log"
 	"net/http"

--- a/example_test.go
+++ b/example_test.go
@@ -1,8 +1,8 @@
 package s3_test
 
 import (
+	"../s3"
 	"fmt"
-	"github.com/kr/s3"
 	"log"
 	"net/http"
 	"os"

--- a/s3cp/Readme
+++ b/s3cp/Readme
@@ -1,4 +1,4 @@
 Command s3cp copies a file to or from Amazon S3.
 
 Full documentation:
-http://godoc.org/github.com/kr/s3/s3cp
+http://godoc.org/github.com/guymguym/s3/s3cp

--- a/s3cp/main.go
+++ b/s3cp/main.go
@@ -21,7 +21,7 @@
 package main
 
 import (
-	"../s3util"
+	"github.com/guymguym/s3/s3util"
 	"fmt"
 	"io"
 	"os"

--- a/s3cp/main.go
+++ b/s3cp/main.go
@@ -21,8 +21,8 @@
 package main
 
 import (
+	"../s3util"
 	"fmt"
-	"github.com/kr/s3/s3util"
 	"io"
 	"os"
 	"strings"

--- a/s3util/Readme
+++ b/s3util/Readme
@@ -1,4 +1,4 @@
 Package s3util provides streaming transfers to and from Amazon S3.
 
 Full documentation:
-http://godoc.org/github.com/kr/s3/s3util
+http://godoc.org/github.com/guymguym/s3util

--- a/s3util/config.go
+++ b/s3util/config.go
@@ -11,7 +11,7 @@ package s3util
 // TODO(kr): parse error responses; return structured data
 
 import (
-	"../../s3"
+	"github.com/guymguym/s3"
 	"net/http"
 )
 

--- a/s3util/config.go
+++ b/s3util/config.go
@@ -11,7 +11,8 @@ package s3util
 // TODO(kr): parse error responses; return structured data
 
 import (
-	"github.com/kr/s3"
+	"../../s3"
+	"net/http"
 )
 
 var DefaultConfig = &Config{
@@ -23,3 +24,9 @@ type Config struct {
 	*s3.Service
 	*s3.Keys
 }
+
+// Implement the s3.Signer interface
+func (c *Config) Sign(r *http.Request) {
+	c.Service.Sign(r, *c.Keys)
+}
+

--- a/s3util/example_test.go
+++ b/s3util/example_test.go
@@ -1,7 +1,7 @@
 package s3util_test
 
 import (
-	"github.com/kr/s3/s3util"
+	"../s3util"
 	"io"
 	"os"
 )

--- a/s3util/example_test.go
+++ b/s3util/example_test.go
@@ -1,7 +1,7 @@
 package s3util_test
 
 import (
-	"../s3util"
+	"github.com/guymguym/s3/s3util"
 	"io"
 	"os"
 )

--- a/s3util/open.go
+++ b/s3util/open.go
@@ -1,7 +1,7 @@
 package s3util
 
 import (
-	"../../s3"
+	"github.com/guymguym/s3"
 	"io"
 	"net/http"
 	"time"

--- a/s3util/open.go
+++ b/s3util/open.go
@@ -1,6 +1,7 @@
 package s3util
 
 import (
+	"../../s3"
 	"io"
 	"net/http"
 	"time"
@@ -9,15 +10,15 @@ import (
 // Open requests the S3 object at url. An HTTP status other than 200 is
 // considered an error.
 //
-// If c is nil, Open uses DefaultConfig.
-func Open(url string, c *Config) (io.ReadCloser, error) {
-	if c == nil {
-		c = DefaultConfig
+// If signer is nil, Open uses DefaultConfig.
+func Open(url string, signer s3.Signer) (io.ReadCloser, error) {
+	if signer == nil {
+		signer = DefaultConfig
 	}
 	// TODO(kr): maybe parallel range fetching
 	r, _ := http.NewRequest("GET", url, nil)
 	r.Header.Set("Date", time.Now().UTC().Format(http.TimeFormat))
-	c.Sign(r, *c.Keys)
+	signer.Sign(r)
 	resp, err := http.DefaultClient.Do(r)
 	if err != nil {
 		return nil, err

--- a/s3util/uploader.go
+++ b/s3util/uploader.go
@@ -1,7 +1,7 @@
 package s3util
 
 import (
-	"../../s3"
+	"github.com/guymguym/s3"
 	"bytes"
 	"encoding/xml"
 	"io"

--- a/sign.go
+++ b/sign.go
@@ -39,6 +39,12 @@ var signParams = map[string]bool{
 	"website":                      true,
 }
 
+// The Signer interface describes a sign-able entity.
+// Implemented by s3util.Config for signing with known keys.
+type Signer interface {
+	Sign(r *http.Request)
+}
+
 // Keys holds a set of Amazon Security Credentials.
 type Keys struct {
 	AccessKey string


### PR DESCRIPTION
Now s3util can take a more generic Signer interface instead of the fixed
s3util.Config, which is needed to allow uploads from clients that shouldn't
have the secret key, and therefore requests a web server to sign its requests.
