### PR TITLE
Signed query

### DIFF
--- a/sign.go
+++ b/sign.go
@@ -72,8 +72,8 @@ func Sign(r *http.Request, k Keys) {
 	DefaultService.Sign(r, k)
 }
 
-func SignURL(r *http.Request, t time.Time, k Keys) {
-	DefaultService.SignURL(r, t, k)
+func SignQuery(r *http.Request, t time.Time, k Keys) {
+	DefaultService.SignQuery(r, t, k)
 }
 
 // Service represents an S3-compatible service.
@@ -94,12 +94,12 @@ func (s *Service) Sign(r *http.Request, k Keys) {
 	r.Header.Set("Authorization", "AWS "+k.AccessKey+":"+string(sig))
 }
 
-func (s *Service) SignURL(r *http.Request, t time.Time, k Keys) {
+func (s *Service) SignQuery(r *http.Request, t time.Time, k Keys) {
 	if k.SecurityToken != "" {
 		r.Header.Set("X-Amz-Security-Token", k.SecurityToken)
 	}
 	h := hmac.New(sha1.New, []byte(k.SecretKey))
-	s.writeSigURLData(h, r, t)
+	s.writeSigQueryData(h, r, t)
 	sig := make([]byte, base64.StdEncoding.EncodedLen(h.Size()))
 	base64.StdEncoding.Encode(sig, h.Sum(nil))
 	r.URL.RawQuery = "AWSAccessKeyId="+k.AccessKey+"&Signature="+string(sig)+"&Expires="+string(t.Unix())
@@ -120,7 +120,7 @@ func (s *Service) writeSigData(w io.Writer, r *http.Request) {
 	s.writeResource(w, r)
 }
 
-func (s *Service) writeSigURLData(w io.Writer, r *http.Request, t time.Time) {
+func (s *Service) writeSigQueryData(w io.Writer, r *http.Request, t time.Time) {
 	w.Write([]byte(r.Method))
 	w.Write([]byte{'\n'})
 	w.Write([]byte(r.Header.Get("content-md5")))


### PR DESCRIPTION
Pass the signature as a [query parameter](http://s3.amazonaws.com/doc/s3-developer-guide/RESTAuthentication.html). Takes a `time.Time` parameter. Don't love the SignURL name - SignQuery?

Duplicating writeSigData with writeSigURLData - could fold these in to the same routine, and check for whether a time value got passed in and the either do `data' or`expires`.

Not sure if this works. Also needs tests.
