### PR TITLE
Add s3util.List() for getting entries in a directory

### DIFF
--- a/s3util/example_test.go
+++ b/s3util/example_test.go
@@ -25,7 +25,7 @@ func ExampleOpen() {
 	w.Close()
 }
 
-func ExampleList() {
+func ExampleReaddir() {
 	s3util.DefaultConfig.AccessKey = os.Getenv("S3_ACCESS_KEY")
 	s3util.DefaultConfig.SecretKey = os.Getenv("S3_SECRET_KEY")
 	f, err := s3util.NewFile("https://examle.s3.amazonaws.com/foo", nil)
@@ -34,7 +34,7 @@ func ExampleList() {
 	}
 	var infos []os.FileInfo
 	for {
-		infos, err = f.List(0)
+		infos, err = f.Readdir(0)
 		if err == io.EOF {
 			break
 		} else if err != nil {


### PR DESCRIPTION
Here is my implemention for APIs proposed in https://github.com/kr/s3/pull/7#issuecomment-20946552

Note: s3uti.Open() is already taken, so I used the name NewFile() instead.
Can you propose a better name?

``` go
func NewFile(url string, c *Config) (*File, error)

func (f *File) List(n int) ([]os.FileInfo, error)
```
