### PR TITLE
Add s3util.Delete function

### DIFF
--- a/s3util/delete.go
+++ b/s3util/delete.go
@@ -1,0 +1,32 @@
+package s3util
+
+import (
+	"io"
+	"net/http"
+	"time"
+)
+
+// Delete deletes the S3 object at url. An HTTP status other than 204 (No
+// Content) is considered an error.
+//
+// If c is nil, Delete uses DefaultConfig.
+func Delete(url string, c *Config) (io.ReadCloser, error) {
+	if c == nil {
+		c = DefaultConfig
+	}
+	r, _ := http.NewRequest("DELETE", url, nil)
+	r.Header.Set("Date", time.Now().UTC().Format(http.TimeFormat))
+	c.Sign(r, *c.Keys)
+	client := c.Client
+	if client == nil {
+		client = http.DefaultClient
+	}
+	resp, err := client.Do(r)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusNoContent {
+		return nil, newRespError(resp)
+	}
+	return resp.Body, nil
+}

--- a/s3util/example_test.go
+++ b/s3util/example_test.go
@@ -15,6 +15,13 @@ func ExampleCreate() {
 	w.Close()
 }
 
+func ExampleDelete() {
+	s3util.DefaultConfig.AccessKey = "...access key..."
+	s3util.DefaultConfig.SecretKey = "...secret key..."
+	r, _ := s3util.Delete("https://mybucket.s3.amazonaws.com/log.txt", nil)
+	r.Close()
+}
+
 func ExampleOpen() {
 	s3util.DefaultConfig.AccessKey = "...access key..."
 	s3util.DefaultConfig.SecretKey = "...secret key..."


### PR DESCRIPTION
This PR adds an `s3util.Delete` function and a corresponding example. I manually tested the functionality (putting in my real AWS S3 credentials) and it worked.
