### PR TITLE
Enable signing when request.URL has been manually set

### DIFF
--- a/sign.go
+++ b/sign.go
@@ -119,7 +119,7 @@ func (s *Service) writeSigData(w io.Writer, r *http.Request) {
 }
 
 func (s *Service) writeResource(w io.Writer, r *http.Request) {
-	s.writeVhostBucket(w, strings.ToLower(r.Host))
+	s.writeVhostBucket(w, strings.ToLower(r.URL.Host))
 	path := r.URL.RequestURI()
 	if r.URL.RawQuery != "" {
 		path = path[:len(path)-len(r.URL.RawQuery)-1]


### PR DESCRIPTION
I recently came across an issue with encoding + and ? in the path component of S3 files. See this thread on the mailing list for context: https://groups.google.com/forum/#!topic/golang-nuts/CbL27WPZavY

I could get around the issue by manually setting request.URL on the request object. Doing so doesn't set request.Host which causes signing to fail. This diff pulls the host from request.URL. This is consistent with how the other url portions are accessed, e.g. `r.URL.RawQuery`.
