### PR TITLE
Add the ability to pause/resume s3util uploads

### DIFF
--- a/s3util/Readme
+++ b/s3util/Readme
@@ -1,4 +1,8 @@
 Package s3util provides streaming transfers to and from Amazon S3.
 
+This branch offers Pause/Resume methods so a multipart upload may be stopped,
+its state persisted, and then loaded later (perhaps in a completely new
+process).
+
 Full documentation:
 http://godoc.org/github.com/kr/s3/s3util

--- a/s3util/uploader.go
+++ b/s3util/uploader.go
@@ -210,8 +210,7 @@ func (u *Uploader) Pause() (*UploaderState, error) {
 	// We can't flush parts less than the min size, so we have to persist them.
 	var buf []byte
 	if u.off > 0 && u.off < MinPartSize {
-		buf = make([]byte, u.off)
-		copy(buf, u.buf)
+		buf = u.buf[:u.off]
 		u.buf, u.off = nil, 0
 	}
 

--- a/s3util/uploader_test.go
+++ b/s3util/uploader_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 )
 
-func runUpload(t *testing.T, makeCloser func(io.Reader) io.ReadCloser) *uploader {
+func runUpload(t *testing.T, makeCloser func(io.Reader) io.ReadCloser) *Uploader {
 	c := *DefaultConfig
 	c.Client = &http.Client{
 		Transport: RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
@@ -32,11 +32,11 @@ func runUpload(t *testing.T, makeCloser func(io.Reader) io.ReadCloser) *uploader
 			return resp, nil
 		}),
 	}
-	u, err := newUploader("https://s3.amazonaws.com/foo/bar", nil, &c)
+	u, err := Create("https://s3.amazonaws.com/foo/bar", nil, &c)
 	if err != nil {
 		t.Fatal("unexpected err", err)
 	}
-	const size = minPartSize + minPartSize/3
+	const size = MinPartSize + MinPartSize/3
 	n, err := io.Copy(u, io.LimitReader(devZero, size))
 	if err != nil {
 		t.Fatal("unexpected err", err)
@@ -65,7 +65,7 @@ func TestUploaderCloseRespBody(t *testing.T) {
 }
 
 // Used in TestUploaderFreesBuffers to force liveness.
-var DummyUploader *uploader
+var DummyUploader *Uploader
 
 func TestUploaderFreesBuffers(t *testing.T) {
 	var m0, m1 runtime.MemStats
@@ -83,8 +83,8 @@ func TestUploaderFreesBuffers(t *testing.T) {
 	// The uploader never allocates buffers smaller than minPartSize,
 	// so if the increase is < minPartSize we know none are reachable.
 	inc := m1.Alloc - m0.Alloc
-	if m1.Alloc > m0.Alloc && inc >= minPartSize {
-		t.Errorf("inc = %d want <%d", inc, minPartSize)
+	if m1.Alloc > m0.Alloc && inc >= MinPartSize {
+		t.Errorf("inc = %d want <%d", inc, MinPartSize)
 	}
 }
 


### PR DESCRIPTION
Problem:

Right now there's no way to gracefully shutdown a process mid-upload. The upload struct is private - as are a number of key pieces of state.

Proposed Solution:

Add a Pause method and a Resume function to allow for graceful shutdowns and starting back up.

Implementation details:
- **The Public API has not changed.** However, I've expanded the breadth of the public API which may make compatibility harder to maintain in the future.
- The return value of Pause, UploaderState, makes every field public to allow users to marshal it as they see fit. (Although I haven't written custom marshaling code yet, so I wonder if the `part` type will need to be made public to support some use cases.)
- Resume requires a Config in addition to the UploaderState since http clients can't be automatically marshalled (not to mention callers may not want their sensitive credentials included in the uploader state).
- I wrote a number of integration tests locally using my own S3 keys, but I didn't commit them because they're slow and require S3 keys. If you're curious, here's most of the code: https://gist.github.com/schmichael/a888d7ce5a0a9182d7c9
