### PR TITLE
Check that ETag is long enough to slice

### DIFF
--- a/s3util/uploader.go
+++ b/s3util/uploader.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/xml"
 	"github.com/kr/s3"
+	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -190,8 +191,8 @@ func (u *uploader) putPart(p *part) error {
 		return newRespError(resp)
 	}
 	s := resp.Header.Get("etag") // includes quote chars for some reason
-	if len(s) > 1 {
-		p.ETag = s[1 : len(s)-1]
+	if len(s) < 2 {
+		return fmt.Errorf("received invalid etag %q", s)
 	}
 	return nil
 }

--- a/s3util/uploader_test.go
+++ b/s3util/uploader_test.go
@@ -146,14 +146,14 @@ func TestEmptyEtag(t *testing.T) {
 	}
 	const size = minPartSize + minPartSize/3
 	n, err := io.Copy(u, io.LimitReader(devZero, size))
-	if err != nil {
-		t.Fatal("unexpected err", err)
+	if err == nil || err.Error() != `received invalid etag ""` {
+		t.Fatalf("expected err: %q", err)
 	}
-	if n != size {
-		t.Fatal("wrote %d bytes want %d", n, size)
+	if n != minPartSize {
+		t.Fatalf("wrote %d bytes want %d", n, minPartSize)
 	}
 	err = u.Close()
-	if err != nil {
-		t.Fatal("unexpected err", err)
+	if err == nil || err.Error() != `received invalid etag ""` {
+		t.Fatalf("expected err: %q", err)
 	}
 }


### PR DESCRIPTION
Slicing the ETag header to remove the quotes that typically surround the
content will cause a panic if the string is less than 2 bytes long.

Fixes #26.
