### PR TITLE
Fix ETag

### DIFF
--- a/s3util/uploader.go
+++ b/s3util/uploader.go
@@ -194,6 +194,7 @@ func (u *uploader) putPart(p *part) error {
 	if len(s) < 2 {
 		return fmt.Errorf("received invalid etag %q", s)
 	}
+	p.ETag = s[1 : len(s)-1]
 	return nil
 }
 

--- a/s3util/uploader_test.go
+++ b/s3util/uploader_test.go
@@ -19,6 +19,10 @@ func runUpload(t *testing.T, makeCloser func(io.Reader) io.ReadCloser) *uploader
 			case req.Method == "POST" && q["uploads"] != nil:
 				s = `<UploadId>foo</UploadId>`
 			case req.Method == "POST" && q["uploadId"] != nil:
+				b, _ := ioutil.ReadAll(req.Body)
+				if !strings.Contains(string(b), "<ETag>foo</ETag>") {
+					t.Error("missing ETag")
+				}
 			default:
 				t.Fatal("unexpected request", req)
 			}


### PR DESCRIPTION
https://github.com/kr/s3/pull/27 inadvertently removed the setting of ETag in `s3util.part`. This adds it back (after the length check) and now tests that it's there.