### PR TITLE
added link to RapidAPI

### DIFF
--- a/Readme
+++ b/Readme
@@ -1,4 +1,7 @@
 Package s3 signs HTTP requests for use with Amazon’s S3 API.
 
+Test here on RapidAPI: 
+https://rapidapi.com/package/AmazonS3?utm_source=AmazonS3Github&utm_medium=button&utm_content=Vender_GitHub
+
 Documentation:
 http://godoc.org/github.com/kr/s3


### PR DESCRIPTION
Hey there. I added a link in your README to a tool where you can test out AmazonS3 API calls in your browser before using your SDK to connect to the API. I've added it to these other SDKs (Telegram, Shopify and LinkedIn) and gotten feedback that it was pretty useful. If anything, let me know what you think and if you have any feedback. I'm part of the team that built this tool and we're always looking to make it better!